### PR TITLE
Add manual ack mode to consume interface.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:3-management
+        ports:
+          - 5672:5672
 
     steps:
     - uses: actions/checkout@v2
@@ -59,6 +64,7 @@ jobs:
         coverage run --source rabbitmq_client -m unittest \
           tests.test_connection \
           tests.test_consumer \
-          tests.test_producer -f
+          tests.test_producer \
+          tests.test_integration -f
         coverage report -m --fail-under 96
     # TODO: Add integration tests

--- a/README.md
+++ b/README.md
@@ -45,6 +45,38 @@ delayed until it is. When a consume has been successfully started, the bound
 callback will receive a ``ConsumeOK`` object containing the resulting 
 consumer tag.
 
+### Manual ack mode
+
+By default, the consumer will automatically send a ``basic_ack`` for each consumed
+message. By passing the ``manual_ack`` kwarg to the ``consume`` interface 
+you can opt to manually acknowledge incoming messages:
+
+```python
+from rabbitmq_client import RMQConsumer, ConsumeParams, QueueParams
+
+from some_other_module import handle_msg
+
+
+def on_message(msg, ack=None):
+    error = handle_msg(msg)
+    
+    if not error:
+        ack()
+
+consumer = RMQConsumer()
+consumer.start()
+consumer.consume(ConsumeParams(on_message),
+                 queue_params=QueueParams("queue_name"),
+                 manual_ack=True)
+```
+
+Above is an example of how to enable manual ack mode. When manual ack mode is
+enabled, the ``on_message_callback`` parameter of the ``ConsumeParams`` object
+must accept the additional ``ack`` kwarg. The ``ack`` kwarg is a function
+which, when called, acknowledges the message which prompted the call to the
+``on_message_callback``. This leaves it up to the user to decide when to ack
+an incoming message.
+
 ## Producer
 `RMQProducer` extends the `RMQConnection` base class with two additional 
 methods: `publish` and `activate_confirm_mode`. Publish is used, as it 

--- a/test_consumer.py
+++ b/test_consumer.py
@@ -3,10 +3,8 @@ import logging
 import threading
 import sys
 
-from pika.exchange_type import ExchangeType
-
-from rabbitmq_client import RMQConsumer, ConsumeOK
-from rabbitmq_client import ConsumeParams, ExchangeParams
+from rabbitmq_client import RMQConsumer, ConsumeOK, QueueParams
+from rabbitmq_client import ConsumeParams
 
 
 logger = logging.getLogger("rabbitmq_client")
@@ -28,18 +26,18 @@ def stop(*args):
 signal.signal(signal.SIGINT, stop)
 
 
-def on_msg(message):
+def on_msg(message, ack=None):
     if isinstance(message, ConsumeOK):
         print("GOT CONSUME OK")
     else:
         print(f"GOT MESSAGE: {message}")
+        ack()
 
 
 consumer.consume(
     ConsumeParams(on_msg),
-    exchange_params=ExchangeParams("direct",
-                                   exchange_type=ExchangeType.fanout),
-    routing_key="rkey"
+    queue_params=QueueParams("queue"),
+    manual_ack=True
 )
 
 threading.Event().wait()

--- a/test_producer.py
+++ b/test_producer.py
@@ -1,13 +1,9 @@
 import signal
 import logging
 import threading
-import time
-
 import sys
 
-from pika.exchange_type import ExchangeType
-
-from rabbitmq_client import RMQProducer, QueueParams, ExchangeParams
+from rabbitmq_client import RMQProducer, QueueParams
 
 
 logger = logging.getLogger("rabbitmq_client")
@@ -29,30 +25,5 @@ def stop(*args):
 signal.signal(signal.SIGINT, stop)
 
 producer.publish(b"queue publish 1", queue_params=QueueParams("queue"))
-producer.publish(b"queue publish 2", queue_params=QueueParams("queue"))
-producer.publish(b"queue publish 3", queue_params=QueueParams("queue"))
-producer.publish(b"exchange publish 1",
-                 exchange_params=ExchangeParams("direct"),
-                 routing_key="rkey")
-producer.publish(
-    b"exchange publish 2",
-    exchange_params=ExchangeParams("fanout",
-                                   exchange_type=ExchangeType.fanout))
-
-time.sleep(0.3)
-producer.activate_confirm_mode(lambda x: print(x))
-producer.publish(
-    b"exchange publish 2",
-    exchange_params=ExchangeParams("fanout",
-                                   exchange_type=ExchangeType.fanout))
-producer.publish(
-    b"exchange publish 2",
-    exchange_params=ExchangeParams("fanout",
-                                   exchange_type=ExchangeType.fanout))
-producer.publish(
-    b"exchange publish 2",
-    exchange_params=ExchangeParams("fanout",
-                                   exchange_type=ExchangeType.fanout))
-
 
 threading.Event().wait()


### PR DESCRIPTION
Consumes shall be possible to manually acknowledge incoming messages, rather
than always relying on the consumer's auto-ack. Auto-ack shall remain the default
for BC purposes.

To enable manual ack mode, pass manual_ack=True to the consume interface function.
Manual ack mode will lead to an additional kwarg being passed to the
on_message_callback: "ack". This new kawrg is a function that when called sends a
basic_ack for the message in question (the reason for on_message_callback being
called).